### PR TITLE
Allow darkmode settings to persist in a cookie when the user is not logged in

### DIFF
--- a/cgi/templates/darkmode.ejs
+++ b/cgi/templates/darkmode.ejs
@@ -1,0 +1,7 @@
+<% if (request.user.valid) { %>
+    <label class="darkmode-toggle" title="Theme">
+        <input class="checkbox" name="darkmode-toggle" type="checkbox" <%= request.user.attributes.dark ? 'checked="checked"' : '' %> />
+        <span class="slider round"></span>
+    </label>
+<% } %>
+<script type="text/javascript" src="<%= cacheBuster('js/darkmode-toggle.js') %>"></script>

--- a/cgi/templates/headers.ejs
+++ b/cgi/templates/headers.ejs
@@ -33,10 +33,5 @@
             </tr>
         </tbody>
     </table>
-
-    <label class="darkmode-toggle" title="Theme">
-        <input class="checkbox" name="darkmode-toggle" type="checkbox" <%= request.user.attributes.dark ? 'checked="checked"' : '' %> />
-        <span class="slider round"></span>
-        <script type="text/javascript" src="<%= cacheBuster('js/darkmode-toggle.js') %>"></script>
-    </label>
+    <%- include('darkmode.ejs', {request}); %>
 </div>

--- a/cgi/templates/newaccount.ejs
+++ b/cgi/templates/newaccount.ejs
@@ -5,6 +5,7 @@
 </head>
 
 <body class="<%= request.user.attributes.dark ? "dark-theme" : "light-theme" %>">
+    <%- include('darkmode.ejs', {request}); %>
     <div id="site">
         <div id="content">
             <div class="absc db">

--- a/cgi/templates/resetpassword.ejs
+++ b/cgi/templates/resetpassword.ejs
@@ -3,6 +3,7 @@
     <%- include('head_shit.ejs', {title: 'EWMA | Password Reset', request: request, cacheBuster: cacheBuster}); %>
 </head>
 <body class="<%= request.user.attributes.dark ? "dark-theme" : "light-theme" %>">
+    <%- include('darkmode.ejs', {request}); %>
     <div id="site">
         <div id="content">
             <div class="absc db">

--- a/cgi/templates/tos.ejs
+++ b/cgi/templates/tos.ejs
@@ -6,6 +6,7 @@
 </head>
 
 <body class="<%= request.user.attributes.dark ? "dark-theme" : "light-theme" %>">
+    <%- include('darkmode.ejs', {request}); %>
     <div id="site">
         <div class="absc db">
             <a href="/">

--- a/cgi/templates/useapasswordmanager.ejs
+++ b/cgi/templates/useapasswordmanager.ejs
@@ -3,6 +3,7 @@
     <%- include('head_shit.ejs', {title: 'EWMA | Password Reset', request: request, cacheBuster: cacheBuster}); %>
 </head>
 <body class="<%= request.user.attributes.dark ? "dark-theme" : "light-theme" %>">
+    <%- include('darkmode.ejs', {request}); %>
     <div id="site">
         <div id="content">
             <div class="absc db">

--- a/static/js/darkmode-toggle.js
+++ b/static/js/darkmode-toggle.js
@@ -1,9 +1,23 @@
 function toggleDarkMode(state) {
-    if (state) {
+    if (typeof state === 'undefined') {
+        // no theme slider on this page - use the cookie if we have it
+        let theme = getThemeCookie();
+        if (theme) {
+            $('body').removeClass('dark-theme').removeClass('light-theme').addClass(`${theme}-theme`);
+        }
+    } else if (state) {
         $('body').addClass('dark-theme').removeClass('light-theme');
     } else {
         $('body').removeClass('dark-theme').addClass('light-theme');
     }
+}
+
+function getThemeCookie() {
+    let cookie = document.cookie.split('; ').find(x => x.startsWith('theme='));
+    if (!cookie) {
+        return null;
+    }
+    return cookie.split('=')[1];
 }
 
 $(document).ready(function() {
@@ -11,6 +25,12 @@ $(document).ready(function() {
         let $this = $(this);
 
         toggleDarkMode($this.prop('checked'));
+
+        let newValue = $this.prop('checked') ? 'dark' : 'light';
+        let existingCookie = getThemeCookie();
+        if (existingCookie === null || existingCookie !== newValue) {
+            document.cookie = `theme=${newValue}; path=/; max-age=315360000`;
+        }
 
         $.ajax({
             url: `/darkmode/${$this.prop('checked') ? 'on' : 'off'}`,


### PR DESCRIPTION
This is an alternate solution for #16 that still respects settings of a user when they are not logged in.